### PR TITLE
Fix code scanning alert no. 3: CSRF protection not enabled

### DIFF
--- a/app/controllers/authorio/authorio_controller.rb
+++ b/app/controllers/authorio/authorio_controller.rb
@@ -2,6 +2,7 @@
 
 module Authorio
   class AuthorioController < ActionController::Base
+    protect_from_forgery with: :exception
     layout "authorio/main"
 
     helper_method :logged_in?, :rememberable?, :current_user,


### PR DESCRIPTION
Fixes [https://github.com/Libreverse/authorio-updated/security/code-scanning/3](https://github.com/Libreverse/authorio-updated/security/code-scanning/3)

To fix the CSRF vulnerability, we need to enable CSRF protection in the `AuthorioController` class. The best way to do this is by adding a call to `protect_from_forgery` with the `:exception` strategy. This will raise an exception if an invalid CSRF token is provided, ensuring that the session is not compromised.

We will add the `protect_from_forgery with: :exception` line in the `AuthorioController` class, ideally at the beginning of the class definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
