### PR TITLE
Fix code scanning alert no. 1: CSRF protection not enabled

### DIFF
--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Fixes [https://github.com/Libreverse/authorio-updated/security/code-scanning/1](https://github.com/Libreverse/authorio-updated/security/code-scanning/1)

To fix the CSRF vulnerability, we need to enable CSRF protection in the `ApplicationController` class. The best way to do this is by adding a call to `protect_from_forgery` with the `:exception` strategy. This will raise an exception if an invalid CSRF token is provided, ensuring that the session is not compromised.

We need to modify the `ApplicationController` class in the file `test/dummy/app/controllers/application_controller.rb` to include this call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
